### PR TITLE
Add a new option for repacking of extracted mods

### DIFF
--- a/TML.Files/Generic/Utilities/FileUtilities.cs
+++ b/TML.Files/Generic/Utilities/FileUtilities.cs
@@ -21,5 +21,22 @@ namespace TML.Files.Generic.Utilities
 
             return decompressed;
         }
+        
+        /// <summary>
+        ///     Uses a <see cref="MemoryStream"/> and <see cref="DeflateStream"/> to compress a file, given the data.
+        /// </summary>
+        /// <param name="data"></param>
+        /// <returns></returns>
+        public static byte[] CompressFile(byte[] data)
+        {
+            MemoryStream dataStream = new(data);
+            MemoryStream compressStream = new();
+
+            DeflateStream deflateStream = new(compressStream, CompressionMode.Compress);
+            dataStream.CopyTo(deflateStream);
+            deflateStream.Dispose();
+
+            return compressStream.ToArray();
+        }
     }
 }

--- a/TML.Patcher.Backend/Packing/RepackRequest.cs
+++ b/TML.Patcher.Backend/Packing/RepackRequest.cs
@@ -1,0 +1,178 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading.Tasks;
+using TML.Files.Generic.Files;
+using TML.Files.Generic.Utilities;
+using TML.Files.Specific.Files;
+
+namespace TML.Patcher.Backend.Packing
+{
+    public sealed class RepackRequest
+    {
+        private const string ModFileHeader = "TMOD"; // Bytes for TMOD
+        
+        public RepackRequest(DirectoryInfo repackDirectory, string targetFilePath, ModData modData, double threads)
+        {
+            RepackDirectory = repackDirectory;
+            TargetFilePath = targetFilePath;
+            ModData = modData;
+            Threads = threads;
+        }
+
+        public DirectoryInfo RepackDirectory { get; }
+
+        public string TargetFilePath { get; }
+        
+        public ModData ModData { get; }
+        
+        public double Threads { get; private set;  }
+
+        public void ExecuteRequest()
+        {
+            ConcurrentBag<FileEntryData> entries = ConvertFilesToEntries();
+            MemoryStream modStream = ConvertToModStream(entries);
+            SaveModFile(modStream, TargetFilePath);
+        }
+
+        private MemoryStream ConvertToModStream(IEnumerable<FileEntryData> entriesEnumerable)
+        {
+            // Convert entries IEnumerable to an array
+            FileEntryData[] entries = entriesEnumerable.ToArray();
+            
+            MemoryStream modStream = new();
+            BinaryWriter modWriter = new(modStream);
+            
+            // Write the header
+            modWriter.Write(Encoding.UTF8.GetBytes(ModFileHeader));
+            
+            // Write the mod loader version
+            modWriter.Write(ModData.modLoaderVersion.ToString());
+            
+            // Store the position of the hash
+            long hashPos = modStream.Position;
+            
+            // Skip 20 + 256 + 4 bytes of the hash, browser signature, and file data length
+            modStream.Seek(20 + 256 + 4, SeekOrigin.Current);
+            
+            // Store the position of the start of the mod's data
+            long dataPos = modStream.Position;
+            
+            // Write the mod's internal name
+            modWriter.Write(ModData.modName);
+            
+            // Write the mod's version
+            modWriter.Write(ModData.modVersion.ToString());
+            
+            // Write the number of files in the .tmod file
+            modWriter.Write(entries.Length);
+            
+            // Iterate over all entries and write:
+            // * File path
+            // * Uncompressed length
+            // * Compressed length
+            foreach (FileEntryData entry in entries)
+            {
+                modWriter.Write(entry.fileName);
+                modWriter.Write(entry.fileLengthData.length);
+                modWriter.Write(entry.fileLengthData.lengthCompressed);
+            }
+            
+            // Iterate over all entries and write the entry bytes
+            foreach (FileEntryData entry in entries)
+                modWriter.Write(entry.fileData);
+            
+            // Go to the start of the mod's data to calculate the hash
+            modStream.Position = dataPos;
+            byte[] hash = SHA1.Create().ComputeHash(modStream);
+            
+            // Go to the hash position to write the hash
+            modStream.Position = hashPos;
+            modWriter.Write(hash);
+            
+            // Skip the mod browser signature
+            modStream.Seek(256, SeekOrigin.Current);
+            
+            // Calculate the bytes of the mod's data and write it
+            int modBytes = (int) (modStream.Length - dataPos);
+            modWriter.Write(modBytes);
+
+            modStream.Position = 0;
+            return modStream;
+        }
+        
+        private static void SaveModFile(MemoryStream modStream, string targetFilePath)
+        {
+            FileStream fileStream = new(targetFilePath, FileMode.Create);
+            modStream.CopyTo(fileStream);
+            fileStream.Dispose();
+        }
+
+        private ConcurrentBag<FileEntryData> ConvertFilesToEntries()
+        {
+            List<FileInfo> files = new(RepackDirectory.GetFiles("*", SearchOption.AllDirectories));
+            
+            List<List<FileInfo>> chunks = new();
+
+            ConcurrentBag<FileEntryData> fileBag = new();
+
+            if (Threads <= 0)
+                Threads = 1D;
+
+            double numThreads = 
+                Math.Min(files.Count, Threads); // use either the amount of configured threads or the amount of files (whichever is lower)
+            int chunkSize = (int) Math.Round(files.Count / numThreads, MidpointRounding.AwayFromZero);
+
+            // Split the files into chunks
+            for (int i = 0; i < files.Count; i += chunkSize)
+                chunks.Add(files.GetRange(i, Math.Min(chunkSize, files.Count - i)));
+
+            // Run a task for each chunk
+            // Wait for all tasks to finish
+            Task.WaitAll(chunks.Select(chunk => Task.Run(() => ConvertChunkToEntry(chunk, fileBag, RepackDirectory.FullName))).ToArray());
+
+            return fileBag;
+        }
+
+        private static void ConvertChunkToEntry(IEnumerable<FileInfo> chunk, ConcurrentBag<FileEntryData> fileBag, string baseFolder)
+        {
+            foreach (FileInfo file in chunk)
+            {
+                FileEntryData entryData = new();
+                FileLengthData lengthData = new();
+
+                FileStream fileStream = file.OpenRead();
+                MemoryStream fileMemStream = new();
+                fileStream.CopyTo(fileMemStream);
+
+                // Set the uncompressed length of the file
+                lengthData.length = (int) fileStream.Length;
+                
+                // Check if the file is bigger than 1KB, and if it is, compress it
+                // TODO: Convert compress required size to an option
+                if (fileStream.Length > 1024)
+                {
+                    byte[] compressedStream = FileUtilities.CompressFile(fileMemStream.ToArray());
+                    lengthData.lengthCompressed = compressedStream.Length;
+                    entryData.fileData = compressedStream;
+                }
+                else
+                {
+                    lengthData.lengthCompressed = lengthData.length;
+                    entryData.fileData = fileMemStream.ToArray();
+                }
+
+                // Set the file name of the entry and the length data
+                entryData.fileName = Path.GetRelativePath(baseFolder, file.FullName);
+                entryData.fileLengthData = lengthData;
+                
+                // Add the entry to the concurrent bag
+                fileBag.Add(entryData);
+            }
+        }
+    }
+}

--- a/TML.Patcher.Backend/Packing/RepackRequest.cs
+++ b/TML.Patcher.Backend/Packing/RepackRequest.cs
@@ -35,16 +35,15 @@ namespace TML.Patcher.Backend.Packing
         public void ExecuteRequest()
         {
             ConcurrentBag<FileEntryData> entries = ConvertFilesToEntries();
-            MemoryStream modStream = ConvertToModStream(entries);
-            SaveModFile(modStream, TargetFilePath);
+            ConvertToModFile(entries);
         }
 
-        private MemoryStream ConvertToModStream(IEnumerable<FileEntryData> entriesEnumerable)
+        private void ConvertToModFile(IEnumerable<FileEntryData> entriesEnumerable)
         {
             // Convert entries IEnumerable to an array
             FileEntryData[] entries = entriesEnumerable.ToArray();
             
-            MemoryStream modStream = new();
+            FileStream modStream = new(TargetFilePath, FileMode.Create);
             BinaryWriter modWriter = new(modStream);
             
             // Write the header
@@ -101,8 +100,8 @@ namespace TML.Patcher.Backend.Packing
             int modBytes = (int) (modStream.Length - dataPos);
             modWriter.Write(modBytes);
 
-            modStream.Position = 0;
-            return modStream;
+            // Close the file
+            modStream.Dispose();
         }
         
         private static void SaveModFile(MemoryStream modStream, string targetFilePath)

--- a/TML.Patcher.Backend/Packing/RepackRequest.cs
+++ b/TML.Patcher.Backend/Packing/RepackRequest.cs
@@ -159,7 +159,7 @@ namespace TML.Patcher.Backend.Packing
                 }
 
                 // Set the file name of the entry and the length data
-                entryData.fileName = Path.GetRelativePath(baseFolder, file.FullName);
+                entryData.fileName = Path.GetRelativePath(baseFolder, file.FullName).Replace('\\', '/');
                 entryData.fileLengthData = lengthData;
                 
                 // Add the entry to the concurrent bag

--- a/TML.Patcher.Backend/Packing/RepackRequest.cs
+++ b/TML.Patcher.Backend/Packing/RepackRequest.cs
@@ -103,13 +103,6 @@ namespace TML.Patcher.Backend.Packing
             // Close the file
             modStream.Dispose();
         }
-        
-        private static void SaveModFile(MemoryStream modStream, string targetFilePath)
-        {
-            FileStream fileStream = new(targetFilePath, FileMode.Create);
-            modStream.CopyTo(fileStream);
-            fileStream.Dispose();
-        }
 
         private ConcurrentBag<FileEntryData> ConvertFilesToEntries()
         {

--- a/TML.Patcher.Backend/Packing/RepackRequest.cs
+++ b/TML.Patcher.Backend/Packing/RepackRequest.cs
@@ -146,7 +146,7 @@ namespace TML.Patcher.Backend.Packing
                 
                 // Check if the file is bigger than 1KB, and if it is, compress it
                 // TODO: Convert compress required size to an option
-                if (fileStream.Length > 1024)
+                if (fileStream.Length > 1024 && ShouldCompress(file.Extension))
                 {
                     byte[] compressedStream = FileUtilities.CompressFile(fileMemStream.ToArray());
                     lengthData.lengthCompressed = compressedStream.Length;
@@ -166,5 +166,8 @@ namespace TML.Patcher.Backend.Packing
                 fileBag.Add(entryData);
             }
         }
+
+        private static bool ShouldCompress(string extension) =>
+            extension != ".png" && extension != ".rawimg" && extension != ".ogg" && extension != ".mp3";
     }
 }

--- a/TML.Patcher.Frontend/Common/ConfigurationFile.cs
+++ b/TML.Patcher.Frontend/Common/ConfigurationFile.cs
@@ -30,6 +30,8 @@ namespace TML.Patcher.Frontend.Common
 
         public string ReferencesPath { get; set; } = null!;
 
+        public string RepackPath { get; set; } = null!;
+
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Populate)]
         [DefaultValue(4)]
         public double Threads { get; set; }
@@ -62,6 +64,7 @@ namespace TML.Patcher.Frontend.Common
                 ExtractPath = Path.Combine(Program.ExePath, "Extracted"),
                 DecompilePath = Path.Combine(Program.ExePath, "Decompiled"),
                 ReferencesPath = Path.Combine(Program.ExePath, "References"),
+                RepackPath = Path.Combine(Program.ExePath, "Repacked"),
                 Threads = 4,
                 ProgressBarSize = 16,
                 ItemsPerPage = 10,
@@ -112,6 +115,7 @@ namespace TML.Patcher.Frontend.Common
                 ExtractPath = Program.Configuration.ExtractPath,
                 DecompilePath = Program.Configuration.DecompilePath,
                 ReferencesPath = Program.Configuration.ReferencesPath,
+                RepackPath = Program.Configuration.RepackPath,
                 // TODO: give extract, decompile, & references default values that don't save to the config for portability
                 Threads = Program.Configuration.Threads,
                 ProgressBarSize = Program.Configuration.ProgressBarSize,

--- a/TML.Patcher.Frontend/Common/Options/RepackModOption.cs
+++ b/TML.Patcher.Frontend/Common/Options/RepackModOption.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Diagnostics;
+using System.IO;
+using Consolation.Common.Framework.OptionsSystem;
+using TML.Files.Specific.Files;
+using TML.Patcher.Backend.Packing;
+
+namespace TML.Patcher.Frontend.Common.Options
+{
+    public class RepackModOption : ConsoleOption
+    {
+        public override string Text => "Repack a mod.";
+        public override void Execute()
+        {
+            PerformRepack(Utilities.GetModName(Program.Configuration.ExtractPath,
+                "Please enter the name of the mod you want to repack:", true));
+            
+            Program.Patcher.WriteOptionsList(new ConsoleOptions("Return:", Program.Patcher.SelectedOptions));
+        }
+
+        private static void PerformRepack(string pathOrModName)
+        {
+            Patcher window = Program.Patcher;
+            Console.ForegroundColor = ConsoleColor.Yellow;
+            
+            string targetFilePath = Path.Combine(Program.Configuration.RepackPath, pathOrModName);
+            Directory.CreateDirectory(Program.Configuration.RepackPath);
+            string modFolder = Path.Combine(Program.Configuration.ExtractPath, pathOrModName);
+
+            window.WriteLine(1, Program.LightweightLoad 
+                ? "Repacking mod..." 
+                : $"Repacking mod: {pathOrModName}...");
+            Console.ForegroundColor = ConsoleColor.DarkGray;
+            
+            Stopwatch sw = Stopwatch.StartNew();
+
+            new RepackRequest(Directory.CreateDirectory(modFolder), targetFilePath,
+                    new ModData("PotatoKnishes", new Version(0, 11, 8, 4), new Version(1, 2, 3, 4)), Program.Configuration.Threads)
+                .ExecuteRequest();
+            
+            sw.Stop();
+            
+            Console.ForegroundColor = ConsoleColor.White;
+            window.WriteLine($"Finished repacking mod: {pathOrModName}");
+            window.WriteLine($"Repack time: {sw.Elapsed}");
+        }
+    }
+}

--- a/TML.Patcher.Frontend/Patcher.cs
+++ b/TML.Patcher.Frontend/Patcher.cs
@@ -197,6 +197,7 @@ namespace TML.Patcher.Frontend
                 new ListEnabledModsOption(),
                 new UnpackModOption(),
                 new DecompileModOption(),
+                new RepackModOption(),
                 new CreditsAndReleaseNotesOption())
             {
                 DisplayReturn = false,


### PR DESCRIPTION
Repacks folders inside `Extracted` folder to a `.tmod` file

Should it automatically convert `build.txt` files to `Info` files?