### PR TITLE
Add unix support for ilspycmd

### DIFF
--- a/TML.Patcher/Decompilation/DecompilationRequest.cs
+++ b/TML.Patcher/Decompilation/DecompilationRequest.cs
@@ -1,5 +1,6 @@
 ﻿using System.Diagnostics;
 using System.IO;
+using System.Runtime.InteropServices;
 using FileIO = System.IO.File;
 
 namespace TML.Patcher.Decompilation

--- a/TML.Patcher/Decompilation/DecompilationRequest.cs
+++ b/TML.Patcher/Decompilation/DecompilationRequest.cs
@@ -68,7 +68,8 @@ namespace TML.Patcher.Decompilation
             string commandArgs =
                 $"\"{File}\" --referencepath \"{ReferencesPath}\" --outputdir \"{Path.Combine(DecompilePath)}\" --project --languageversion \"CSharp7_3\"";
 
-            ProcessStartInfo ilSpy = new("ilspycmd.exe")
+            bool isWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+            ProcessStartInfo ilSpy = new($"ilspycmd" + (isWindows ? ".exe" : string.Empty))
             {
                 UseShellExecute = false,
                 Arguments = commandArgs


### PR DESCRIPTION
### Description
Only appends `.exe` if on Windows as on unix systems `ilspycmd` does not have file extension.