### PR TITLE
Replace `ilspycmd.exe` with `ICSharpCode.Decompiler`

### DIFF
--- a/TML.Patcher.CLI/Common/ConfigurationFile.cs
+++ b/TML.Patcher.CLI/Common/ConfigurationFile.cs
@@ -52,12 +52,6 @@ namespace TML.Patcher.CLI.Common
         public static string FilePath { get; private set; } = null!;
 
         /// <summary>
-        ///     Whether or not to prompt an ILSpyCMD installation.
-        /// </summary>
-        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Populate)]
-        public bool ShowILSpyCMDInstallPrompt { get; set; }
-
-        /// <summary>
         ///     Mod directory path.
         /// </summary>
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Populate)]
@@ -132,7 +126,6 @@ namespace TML.Patcher.CLI.Common
 
             ConfigurationFile config = new()
             {
-                ShowILSpyCMDInstallPrompt = true,
                 ExtractPath = Path.Combine(Program.ExePath, "Extracted"),
                 DecompilePath = Path.Combine(Program.ExePath, "Decompiled"),
                 ReferencesPath = Path.Combine(Program.ExePath, "References"),
@@ -184,7 +177,6 @@ namespace TML.Patcher.CLI.Common
         {
             ConfigurationFile config = new()
             {
-                ShowILSpyCMDInstallPrompt = Program.Configuration.ShowILSpyCMDInstallPrompt,
                 ModsPath = Program.Configuration.ModsPath,
                 ExtractPath = Program.Configuration.ExtractPath,
                 DecompilePath = Program.Configuration.DecompilePath,

--- a/TML.Patcher.CLI/Program.cs
+++ b/TML.Patcher.CLI/Program.cs
@@ -48,9 +48,8 @@ namespace TML.Patcher.CLI
         /// </summary>
         /// <param name="args">Drag-and-drop file argument array because DragonFruit is funny like that.</param>
         /// <param name="path">File path for extracting a single file quickly.</param>
-        /// <param name="skipILSpyCMDPrompt">Skips the ILSpyCMD installation prompt.</param>
         /// <param name="skipRegistryPrompt">Skips the Windows registry prompt.</param>
-        public static void Main(string[] args, string path = "", bool skipILSpyCMDPrompt = false, bool skipRegistryPrompt = false)
+        public static void Main(string[] args, string path = "", bool skipRegistryPrompt = false)
         {
             Console.Title = "TMLPatcher - by convicted tomatophile";
             Thread.CurrentThread.Name = "Main";
@@ -63,9 +62,6 @@ namespace TML.Patcher.CLI
             PreLoadAssemblies();
             Patcher.InitializeConsoleOptions();
             Patcher.InitializeProgramOptions();
-
-            if (Configuration.ShowILSpyCMDInstallPrompt && !skipILSpyCMDPrompt)
-                InstallILSpyCMD();
 
             if (Configuration.ShowRegistryAdditionPrompt && !skipRegistryPrompt)
                 AddRegistryContext();
@@ -81,52 +77,6 @@ namespace TML.Patcher.CLI
             Patcher.WriteStaticText(false);
             Patcher.CheckForUndefinedPath();
             Patcher.SelectedOptions.ListForOption(Patcher);
-        }
-
-        private static void InstallILSpyCMD()
-        {
-            Configuration.ShowILSpyCMDInstallPrompt = false;
-
-            Patcher window = Patcher;
-
-            window.WriteLine("Do you want to install ilspycmd?");
-            window.WriteLine("<y/n>");
-
-            ConsoleKeyInfo pressedKey = Console.ReadKey();
-            window.WriteLine();
-
-            if (pressedKey.Key != ConsoleKey.Y)
-                return;
-
-            const string dotNetCommand = "dotnet tool install ilspycmd -g";
-
-            window.WriteLine("Attempting to install ilspycmd...");
-
-            Process process = new();
-
-            if (OperatingSystem.IsWindows())
-            {
-                process.StartInfo = new ProcessStartInfo
-                {
-                    FileName = "cmd.exe",
-                    Arguments = "/C " + dotNetCommand,
-                    UseShellExecute = false
-                };
-            }
-            else if (OperatingSystem.IsLinux() || OperatingSystem.IsMacOS())
-            {
-                process.StartInfo = new ProcessStartInfo
-                {
-                    FileName = "bash",
-                    Arguments = "-c \" " + dotNetCommand + " \"",
-                    UseShellExecute = false
-                };
-            }
-            else
-                throw new PlatformNotSupportedException("Unsupported platform for installing ilspycmd.");
-
-            process.Start();
-            process.WaitForExit();
         }
 
         private static void AddRegistryContext()

--- a/TML.Patcher/TML.Patcher.csproj
+++ b/TML.Patcher/TML.Patcher.csproj
@@ -30,4 +30,8 @@
     </None>
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="ICSharpCode.Decompiler" Version="7.1.0.6543" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
This PR replaces `ilspycmd.exe` with the `ICSharpCode.Decompiler` nuget package.
Currently, it:
 - Decompiles the `.dll` into valid C# 7.3 code

It doesn't:
 - Load the `.dll`'s `.pdb` file
 - Support C# 9 for tModLoader 1.4 mods

Should I make it load `.pdb`s or support C# 9? Or is it alright as it is?

#14